### PR TITLE
Feature/separacao front back

### DIFF
--- a/api/config/const.go
+++ b/api/config/const.go
@@ -6,7 +6,7 @@ package config
 
 const (
 	//	defines ip and port address for server instance
-	SERVER_ADDR = "localhost:8080"
+	SERVER_ADDR = "localhost:3000"
 )
 
 /*  =========================
@@ -16,7 +16,7 @@ const (
 const (
 	USER_PATH            = "/read/usuario"
 	USER_ID_PATH         = "/read/usuario/{cod_usuario}"
-	USER_PATH_LOGIN      = "/read/usuario/login"
+	USER_PATH_LOGIN      = "api/read/usuario/login"
 	USER_PATH_CREATEUSER = "/read/usuario/createuser"
 	USER_PATH_DELETEUSER = "/read/usuario/deleteuser"
 )

--- a/api/control/handler.go
+++ b/api/control/handler.go
@@ -15,6 +15,7 @@ func (s *Server) CreateHandler() (r *mux.Router) {
 	r = s.Router
 
 	//	HOME
+	// ?????? /api ????? r.HandleFunc("/api", middlewares.SetMiddleJSON(middlewares.SetMiddleAuth(s.Home))).Methods(http.MethodGet)
 	r.HandleFunc("/", middlewares.SetMiddleJSON(middlewares.SetMiddleAuth(s.Home))).Methods(http.MethodGet)
 
 	/*	=========================

--- a/front/Js/config.js
+++ b/front/Js/config.js
@@ -1,0 +1,1 @@
+const URL_API = 'http://localhost:3000/api';

--- a/front/Js/login.js
+++ b/front/Js/login.js
@@ -67,6 +67,9 @@ function entrar() {
 
   //função fetch para mandar o login e receber o token
   fetch('http://localhost:8080/read/usuario/login', {
+    headers: {
+      'Content-Type': 'application/json'
+    },
     method: 'POST',
     body: corpo,
   }).then(function (response) {

--- a/front/Js/login.js
+++ b/front/Js/login.js
@@ -66,7 +66,7 @@ function entrar() {
   let corpo = JSON.stringify(info);
 
   //função fetch para mandar o login e receber o token
-  fetch('http://localhost:8080/read/usuario/login', {
+  fetch(`${URL_API}/read/usuario/login`, {
     headers: {
       'Content-Type': 'application/json'
     },

--- a/front/index.html
+++ b/front/index.html
@@ -163,6 +163,7 @@
 		</section> <!-- #cd-placeholder-5 -->
 	
 	</main>
+		<script src="./Js/config.js"></script>
 		<script src="./Js/login.js"></script>
 </body>
 


### PR DESCRIPTION
 - Proposta de separar API em porta distinta (3000)
 - Proposta das chamas para API terem rota base /api. Fiz ajuste pontual na rota de login, para exemplo, mas para fazer esta configuração de modo global deve pesquisar no gorilla/mux como fazer. Talvez funcione como colequei no código(handler.go), mas não testei:
```go
// ?????? /api ????? r.HandleFunc("/api",
```
 - Depois podem parametrizar host/porta do server.